### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/memory-safety.yml
+++ b/.github/workflows/memory-safety.yml
@@ -1,5 +1,9 @@
 name: Memory Safety Analysis (ASan + Valgrind)
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/avifenesh/C-refresher/security/code-scanning/4](https://github.com/avifenesh/C-refresher/security/code-scanning/4)

To fix the issue, add a `permissions` block to the root of the workflow file to define the minimal permissions required for the workflow. Based on the actions used in the workflow, the following permissions are appropriate:
- `contents: read` for reading repository files.
- `actions: write` for uploading artifacts.

This ensures that the workflow has only the necessary permissions to complete its tasks without granting excessive access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
